### PR TITLE
Updated jshint-stylish to version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp-istanbul": "0.8.1",
     "gulp-jshint": "1.11.2",
     "gulp-nodeunit": "0.0.5",
-    "jshint-stylish": "1.0.2"
+    "jshint-stylish": "2.0.1"
   },
   "config": {
     "ghooks": {


### PR DESCRIPTION
:rocket:

jshint-stylish just published version 2.0.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 6 commits (ahead by 6, behind by 0).
- [5ef5abe](https://github.com/sindresorhus/jshint-stylish/commit/5ef5abe379d1bd767275b983738fe2243922a153): 2.0.1
- [06c45bb](https://github.com/sindresorhus/jshint-stylish/commit/06c45bba034f204b9f381dc425eb7050d461d318): use `plur`
- [1e20fac](https://github.com/sindresorhus/jshint-stylish/commit/1e20faca42a1aebddc2780b72f853e2dafedfb3e): fix screenshot
- [50c38db](https://github.com/sindresorhus/jshint-stylish/commit/50c38db865ae6dde9c42a2cbdf9b2b4dc016c0f6): 2.0.0
- [a20f8ec](https://github.com/sindresorhus/jshint-stylish/commit/a20f8ec1153be76f52bb2fb2fbac15ed8813139b): minor tweaks
- [40aaa7d](https://github.com/sindresorhus/jshint-stylish/commit/40aaa7d669d1443818cdf60c3b4c25abd1bbabc6): Close #20 PR: Easy require.

See the [full diff](https://github.com/sindresorhus/jshint-stylish/compare/e0e3cf3e992c017eeb6c03ba48a1272583c6db06...5ef5abe379d1bd767275b983738fe2243922a153).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
