### PR TITLE
fix(semver-path): Handle encoded paths

### DIFF
--- a/lib/versioner.js
+++ b/lib/versioner.js
@@ -88,7 +88,7 @@ module.exports = {
     const pathRE = new RegExp(`^${escPPrefix}([~^]?v?${verPattern})`);
 
     return (req, res, next) => {
-      const matches = req.path.match(pathRE);
+      const matches = decodeURIComponent(req.path).match(pathRE);
       if (matches) {
         const [, matched] = matches;
         req.origVersion = matched;

--- a/test/index.js
+++ b/test/index.js
@@ -122,6 +122,15 @@ module.exports = {
         test.done();
       });
     },
+    encodedCaretRange(test) {
+      const middleware = version.setBySemverPath(['v1.0.0']);
+      const req = { path: '/%5Ev1.0.0/foo' };
+      middleware(req, {}, () => {
+        test.equal(req.origVersion, '^v1.0.0', 'Unexpected origVersion');
+        test.equal(req.version, 'v1.0.0', 'Unexpected version');
+        test.done();
+      });
+    },
   },
   setByAccept: {
     setUp(cb) {


### PR DESCRIPTION
`^` can also be represented as `%5E` so decoding the path is desirable for catching both cases.