### PR TITLE
Prevent prerelease lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ app.use(validateVersion([ 'v1', 'v1.1', 'v1.1.1', 'v2' ]));
     request object based on path.
     * `supportedVersions` - An array of versions that are supported.
     * `pathPrefix` - Optional. A path fragment that appears before the version.
+    * `preventPrereleaseLock` - Optional. Set to true if you wish to prevent
+      consumers from locking to a prerelease version. If this is set to true and
+      a locked prerelease is requested the server will respond with a 400.
+      Default `false`
+    * `prereleaseMessage` - Error message to set if a consumer requests a locked
+      prerelease version when preventPrereleaseLock is set to true.
+      Default `'You cannot lock your request to a prerelease version. Use a version range instead.'`
   * `setByAccept(vndPrefix, verSeparator = '.', suffix = '+json')` - Returns an
     express middleware that appends a version property to the request object based
     on accept headers.
@@ -95,6 +102,13 @@ app.use(validateVersion([ 'v1', 'v1.1', 'v1.1.1', 'v2' ]));
     * `verSeparator` - Optional. The separator to use between the vendor prefix
       and version.
     * `suffix` - Optional. The accept header suffix. Default '+json'.
+    * `preventPrereleaseLock` - Optional. Set to true if you wish to prevent
+      consumers from locking to a prerelease version. If this is set to true and
+      a locked prerelease is requested the server will respond with a 400.
+      Default `false`
+    * `prereleaseMessage` - Error message to set if a consumer requests a locked
+      prerelease version when preventPrereleaseLock is set to true.
+      Default `'You cannot lock your request to a prerelease version. Use a version range instead.'`
   * `validateVersion(supportedVersions = [], message = 'Unsupported version requested.')` - 
     Validate that the request version is present and supported.
     * `supportedVersions` - An array of versions that are supported.

--- a/lib/versioner.js
+++ b/lib/versioner.js
@@ -108,7 +108,7 @@ module.exports = {
       if (matches) {
         const [, matched] = matches;
 
-        if (preventPrereleaseLock && semver.valid(matched) && semver.prerelease(matched)) {
+        if (preventPrereleaseLock && semver.prerelease(matched)) {
           return next(createError(400, prereleaseMessage));
         }
 
@@ -230,7 +230,7 @@ module.exports = {
       if (matches) {
         const [, matched] = matches;
 
-        if (preventPrereleaseLock && semver.valid(matched) && semver.prerelease(matched)) {
+        if (preventPrereleaseLock && semver.prerelease(matched)) {
           return next(createError(400, prereleaseMessage));
         }
 

--- a/lib/versioner.js
+++ b/lib/versioner.js
@@ -6,6 +6,8 @@ const semver = require('semver');
 
 const verPattern = '\\d+(\\.\\d+){0,2}[^/]*';
 
+const PRERELEASE_MESSAGE = 'You cannot lock your request to a prerelease version. Use a version range instead.'; // eslint-disable-line max-len
+
 /**
  * Helper method to attempt to convert an invalid semver string into something
  * valid.
@@ -69,6 +71,16 @@ module.exports = {
    * @param {string} pathPrefix
    *   Optional. A path fragment that appears before the version.
    *   Default '/'
+   * @param {boolean} preventPrereleaseLock
+   *   Set to true if you wish to prevent consumers from locking to a prerelease
+   *   version. If this is set to true and a locked prerelease is requested the
+   *   server will respond with a 400.
+   *   Default fase
+   * @param {string} prereleaseMessage
+   *   Error message to set if a consumer requests a locked prerelease version
+   *   when preventPrereleaseLock is set to true.
+   *   Default 'You cannot lock your request to a prerelease version. Use a
+   *            version range instead.'
    *
    * @return {function}
    *   An express middleware that will set req.version as defined by the request
@@ -79,7 +91,11 @@ module.exports = {
    *   // Sets version for paths like /base/v1/thing.
    *   app.use(setVersion('/base'));
    */
-  setBySemverPath(supportedVersions, pathPrefix = '/') {
+  setBySemverPath(
+    supportedVersions,
+    pathPrefix = '/',
+    preventPrereleaseLock = false,
+    prereleaseMessage = PRERELEASE_MESSAGE) {
     if (!Array.isArray(supportedVersions) || !supportedVersions.length) {
       throw new Error('You must define at least one supported version to use this middleware.');
     }
@@ -91,11 +107,16 @@ module.exports = {
       const matches = decodeURIComponent(req.path).match(pathRE);
       if (matches) {
         const [, matched] = matches;
+
+        if (preventPrereleaseLock && semver.valid(matched) && semver.prerelease(matched)) {
+          return next(createError(400, prereleaseMessage));
+        }
+
         req.origVersion = matched;
         req.version = semver.maxSatisfying(supportedVersions, versionValidish(matched));
       }
 
-      next();
+      return next();
     };
   },
 
@@ -160,6 +181,16 @@ module.exports = {
    *   Default '.'
    * @param {string} suffix
    *   Optional. The accept header suffix. Default '+json'.
+   * @param {boolean} preventPrereleaseLock
+   *   Set to true if you wish to prevent consumers from locking to a prerelease
+   *   version. If this is set to true and a locked prerelease is requested the
+   *   server will respond with a 400.
+   *   Default fase
+   * @param {string} prereleaseMessage
+   *   Error message to set if a consumer requests a locked prerelease version
+   *   when preventPrereleaseLock is set to true.
+   *   Default 'You cannot lock your request to a prerelease version. Use a
+   *            version range instead.'
    *
    * @return {function}
    *   An express middleware that will set req.version as defined by an accept
@@ -172,7 +203,13 @@ module.exports = {
    *   // Sets version for accept headers like application/vnd.myorg::1+json.
    *   app.use(setVersion('vnd.myorg', '::');
    */
-  setBySemverAccept(supportedVersions, vndPrefix, verSeparator = '.', suffix = '+json') {
+  setBySemverAccept(
+    supportedVersions,
+    vndPrefix,
+    verSeparator = '.',
+    suffix = '+json',
+    preventPrereleaseLock = false,
+    prereleaseMessage = PRERELEASE_MESSAGE) {
     if (!Array.isArray(supportedVersions) || !supportedVersions.length) {
       throw new Error('You must define at least one supported version to use this middleware.');
     }
@@ -192,11 +229,16 @@ module.exports = {
       const matches = accept.match(acceptRE);
       if (matches) {
         const [, matched] = matches;
+
+        if (preventPrereleaseLock && semver.valid(matched) && semver.prerelease(matched)) {
+          return next(createError(400, prereleaseMessage));
+        }
+
         req.origVersion = matched;
         req.version = semver.maxSatisfying(supportedVersions, versionValidish(matched));
       }
 
-      next();
+      return next();
     };
   },
 


### PR DESCRIPTION
If prereleases are exposed to consumers you may wish to prevent them from being locked in requests. A version range would be safer since as soon as you release a stable version you consumers would receive that instead.

This change will allow you to prevent requests for locked prereleases and instead return a 400 in those cases.