### PR TITLE
Helper function for multi-versioned controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ var validateVersion = require('express-request-version').validateVersion;
 app.use(validateVersion([ 'v1', 'v1.1', 'v1.1.1', 'v2' ]));
 ```
 
+## Helper function
+In your controller files, you can add support for multiple versions by importing the
+`multiVersion` helper:
+```javascript
+...
+router.get(
+'/myPath',
+[other middleware],
+multiVersion({
+  '*': version1,
+  'v0.1.0': version2,
+}))
+
+function version1(req, res) {
+  res.send('This is version 1!')
+}
+
+function version2(req, res) {
+  res.send('This is version 2!')
+}
+```
+Note that a default version marked with `'*'` is mandatory.
+
 ## API
 
   * `setByPath(pathPrefix = '/')` - Returns an express middleware that appends a

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ app.use(validateVersion([ 'v1', 'v1.1', 'v1.1.1', 'v2' ]));
 In your controller files, you can add support for multiple versions by importing the
 `multiVersion` helper:
 ```javascript
+var multiVersion = require('express-request-version').multiVersion;
 ...
 router.get(
 '/myPath',

--- a/lib/versioner.js
+++ b/lib/versioner.js
@@ -3,7 +3,11 @@
 const _ = require('lodash');
 const createError = require('http-errors');
 const semver = require('semver');
-const { cond, flip, map, pipe, propEq, sort, toPairs, T } = require('ramda');
+const {
+  compose, cond, curry,
+  flip, map, pipe, propEq, nAry, sort, toPairs, T } = require('ramda');
+
+const twoArgsFunc = compose(curry, nAry(2));
 
 const verPattern = '\\d+(\\.\\d+){0,2}[^/]*';
 
@@ -324,11 +328,13 @@ module.exports = {
         versionSorter,
         map(
           ([key, fn]) => {
+            const handler = twoArgsFunc(flip(fn))(res);
+
             if (key === '*') {
-              return [T, flip(fn)(res)];
+              return [T, handler];
             }
 
-            return [propEq('version', key), flip(fn)(res)];
+            return [propEq('version', key), handler];
           }))(versions);
 
       return cond(routes)(req);

--- a/lib/versioner.js
+++ b/lib/versioner.js
@@ -3,11 +3,6 @@
 const _ = require('lodash');
 const createError = require('http-errors');
 const semver = require('semver');
-const {
-  compose, cond, curry,
-  flip, map, pipe, propEq, nAry, sort, toPairs, T } = require('ramda');
-
-const twoArgsFunc = compose(curry, nAry(2));
 
 const verPattern = '\\d+(\\.\\d+){0,2}[^/]*';
 
@@ -33,28 +28,31 @@ function versionValidish(version) {
 }
 
 /**
- * Helper method to sort pairs of [versionNumber, function]
+ * Helper method to sort versions
  *
- * @param {Array} pair [version, handler]
- *   Pair of [version, handler] to be tested
+ * @param {String} fst version
+ *   String containing a valid semver version
  *
- * @param {Array} pair [version, handler]
- *   Pair of [version, handler] to be tested
+ * @param {String} snd version
+ *   String containing a valid semver version
  *
- * @return {f}
- *   A sorter function that will return 1 if first argument version is greater
- *   than the second.
+ * @return {Number}
+ *   A number which is 1 if fst < snd, -1 in any other case,
+ *   '*' are always left at the end.
  */
-const versionSorter = sort(([a], [b]) => {
-  if (a === '*') {
+const versionSorter = (fst, snd) => {
+  if (fst === '*') {
     return 1;
   }
-  else if (b === '*') {
+  else if (snd === '*') {
     return -1;
   }
 
-  return a < b;
-});
+  const a = semver.clean(fst);
+  const b = semver.clean(snd);
+
+  return semver.lt(a, b) ? 1 : -1;
+};
 
 module.exports = {
   /**
@@ -323,21 +321,20 @@ module.exports = {
     }
 
     return (req, res) => {
-      const routes = pipe(
-        toPairs,
-        versionSorter,
-        map(
-          ([key, fn]) => {
-            const handler = twoArgsFunc(flip(fn))(res);
+      const pairs = _.toPairs(versions);
+      const sorted = pairs.sort(([a], [b]) => versionSorter(a, b));
+      const routes = sorted.map(([key, fn]) => {
+        const handler = _.partial(_.flip(_.ary(fn, 2)), res);
 
-            if (key === '*') {
-              return [T, handler];
-            }
+        if (key === '*') {
+          return [_.stubTrue, handler];
+        }
 
-            return [propEq('version', key), handler];
-          }))(versions);
+        return [_.matches({ version: key }), handler];
+      });
 
-      return cond(routes)(req);
+      return _.cond(routes)(req);
     };
   },
+  versionSorter,
 };

--- a/lib/versioner.js
+++ b/lib/versioner.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const createError = require('http-errors');
 const semver = require('semver');
+const { cond, flip, map, pipe, propEq, sort, toPairs, T } = require('ramda');
 
 const verPattern = '\\d+(\\.\\d+){0,2}[^/]*';
 
@@ -26,6 +27,30 @@ function versionValidish(version) {
   const [major, minor = '0', patch = '0'] = version.split('.');
   return [major, minor, patch].join('.');
 }
+
+/**
+ * Helper method to sort pairs of [versionNumber, function]
+ *
+ * @param {Array} pair [version, handler]
+ *   Pair of [version, handler] to be tested
+ *
+ * @param {Array} pair [version, handler]
+ *   Pair of [version, handler] to be tested
+ *
+ * @return {f}
+ *   A sorter function that will return 1 if first argument version is greater
+ *   than the second.
+ */
+const versionSorter = sort(([a], [b]) => {
+  if (a === '*') {
+    return 1;
+  }
+  else if (b === '*') {
+    return -1;
+  }
+
+  return a < b;
+});
 
 module.exports = {
   /**
@@ -274,6 +299,39 @@ module.exports = {
       }
 
       return next();
+    };
+  },
+
+  /**
+   * Get multi version handler.
+   *
+   * @param {Object} versions
+   *   An object where keys are version numbers and values are handler
+   *   functions.
+   *
+   * @return {function}
+   *   An express controller that will map requests to the corresponding
+   *   handler function.
+   */
+  multiVersion(versions) {
+    if (typeof versions['*'] !== 'function') {
+      throw new Error('You must provide a default version marked by `*`.');
+    }
+
+    return (req, res) => {
+      const routes = pipe(
+        toPairs,
+        versionSorter,
+        map(
+          ([key, fn]) => {
+            if (key === '*') {
+              return [T, flip(fn)(res)];
+            }
+
+            return [propEq('version', key), flip(fn)(res)];
+          }))(versions);
+
+      return cond(routes)(req);
     };
   },
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "http-errors": "^1.5.1",
     "lodash": "^4.17.2",
-    "ramda": "^0.25.0",
     "semver": "^5.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "http-errors": "^1.5.1",
     "lodash": "^4.17.2",
+    "ramda": "^0.25.0",
     "semver": "^5.3.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const version = require('../lib/versioner');
-const { multiVersion } = require('../lib/versioner');
+const { multiVersion, versionSorter } = require('../lib/versioner');
 
 module.exports = {
   setUp(cb) {
@@ -483,7 +483,7 @@ module.exports = {
       };
 
       const version11 = () => {
-        // not called
+        test.ok(false);
       };
 
       const versions = multiVersion({
@@ -503,7 +503,7 @@ module.exports = {
       });
 
       const version1 = () => {
-        // not called
+        test.ok(false);
       };
 
       const version2 = () => {
@@ -530,6 +530,13 @@ module.exports = {
       test.throws(
         () => multiVersion({ 'v1.0.1': () => {} }),
         'No default handler provided.');
+      test.done();
+    },
+    versionSorter(test) {
+      test.expect(3);
+      test.equal(-1, versionSorter('v3.10.0', 'v3.2.0'));
+      test.equal(1, versionSorter('v3.10.0', 'v3.10.1'));
+      test.equal(-1, versionSorter('v3.10.1', '*'));
       test.done();
     },
   },


### PR DESCRIPTION
This helper function allows users to provide, in a clean way, multiple handlers for supported versions.
As I said in [issue#72](https://github.com/elliotttf/express-request-version/issues/72), this is using ramda helpers, but it can be changed to drop such dependency if you want.