### PR TITLE
update dependency "semver" to fix CVE-2022-25883

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "http-errors": "^1.5.1",
     "lodash": "^4.17.2",
-    "semver": "^5.6.0"
+    "semver": "^7.5.3"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",
@@ -42,6 +42,6 @@
     }
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -533,10 +533,11 @@ module.exports = {
       test.done();
     },
     versionSorter(test) {
-      test.expect(3);
+      test.expect(4);
       test.equal(-1, versionSorter('v3.10.0', 'v3.2.0'));
       test.equal(1, versionSorter('v3.10.0', 'v3.10.1'));
       test.equal(-1, versionSorter('v3.10.1', '*'));
+      test.equal(1, versionSorter('*', 'v3.10.1'));
       test.done();
     },
   },


### PR DESCRIPTION
The currently used server package as a medium vulnerability report that can only be fixed by updating from current 5.x to latest 7.5 version.

Due to the "semver" update the minimum required NodeJS version is increased from the ancient 6 to the 10 which is end-of-live for a long time too.

Please accept this PR and release a new version with this patch to allow others to fix the vulnerability reports.

see CVE-2022-25883 / https://nvd.nist.gov/vuln/detail/CVE-2022-25883